### PR TITLE
[wip] add spacy x.x to run_constrained

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,12 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.8.* *_cpython
 zip_keys:
 - - cdt_name
   - docker_image

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,13 @@
 {% set prefix = "spacy-model-" %}
 {% set name = "en_core_web_" %}
 {% set version = "3.0.0" %}
+{% set build_number = "1" %}
+# see https://github.com/explosion/spacy-models/blob/master/compatibility.json
+# but the pattern _generally_ seems to be x.x
+{% set spacy_version = ".".join(version.split(".")[:2] + ['*']) %}
 
 package:
-  name: {{ prefix|lower }}{{ name[:-1]|lower }}
+  name: {{ prefix }}{{ name[:-1] }}
   version: {{ version }}
 
 source:
@@ -21,15 +25,15 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: {{ build_number }}
 
 requirements:
   host:
-    - python
+    - python >=2.7
     - pip
   run:
     - setuptools
-    - python
+    - python >=2.7
 
 test:
   commands:
@@ -42,66 +46,74 @@ outputs:
       - LICENSE
     build:
       noarch: python
-      number: 0
+      number: {{ build_number }}
       script: cd sm && {{ PYTHON }} -m pip install . --no-deps -vv
     requirements:
       host:
-        - python
+        - python >=2.7
         - pip
       run:
-        - python
+        - python >=2.7
         - setuptools
+      run_constrained:
+        - spacy =={{ spacy_version }}
     test:
       imports:
         - {{ name }}sm
       requires:
-        - spacy {{ version.split('.')[0] }}.{{ version.split('.')[1] }}.*
+        - spacy
       commands:
         - python -c "__import__('{{ name }}sm').load()"
         - python -c "__import__('spacy').load('{{ name }}sm')"
+
   - name: {{ prefix }}{{ name }}md
     files:
       - md
       - LICENSE
     build:
       noarch: python
-      number: 0
+      number: {{ build_number }}
       script: cd md && {{ PYTHON }} -m pip install . --no-deps -vv
     requirements:
       host:
-        - python
+        - python >=2.7
         - pip
       run:
-        - python
+        - python >=2.7
         - setuptools
+      run_constrained:
+        - spacy =={{ spacy_version }}
     test:
       imports:
         - {{ name }}md
       requires:
-        - spacy {{ version.split('.')[0] }}.{{ version.split('.')[1] }}.*
+        - spacy
       commands:
         - python -c "__import__('{{ name }}md').load()"
         - python -c "__import__('spacy').load('{{ name }}md')"
+
   - name: {{ prefix }}{{ name }}lg
     files:
       - lg
       - LICENSE
     build:
       noarch: python
-      number: 0
+      number: {{ build_number }}
       script: cd lg && {{ PYTHON }} -m pip install . --no-deps -vv
     requirements:
       host:
-        - python
+        - python >=2.7
         - pip
       run:
-        - python
+        - python >=2.7
         - setuptools
+      run_constrained:
+        - spacy =={{ spacy_version }}
     test:
       imports:
         - {{ name }}lg
       requires:
-        - spacy {{ version.split('.')[0] }}.{{ version.split('.')[1] }}.*
+        - spacy
       commands:
         - python -c "__import__('{{ name }}lg').load()"
         - python -c "__import__('spacy').load('{{ name }}lg')"


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- for #11
- while still not comfortable making it an actual dependency, this adds a `run_constrained`. i see the _occasionally_ there are some hard examples of _bad_ model versions which aren't compatible with _anything_, but I think we'll just have to roll with it for now